### PR TITLE
Fix news fetcher to use public RSS feeds

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,58 +1,70 @@
 import os
-import requests
+import asyncio
+import feedparser
 from datetime import datetime, timedelta, timezone
 from telegram import Bot
+from telegram.helpers import escape_markdown
 
 print("ENV:", {
-    "API_KEY":   "CRYPTOPANIC_API_KEY" in os.environ,
     "BOT_TOKEN": "TELEGRAM_TOKEN" in os.environ,
     "CHAT_ID":   "CHAT_ID" in os.environ
 })
 
 # --- CONFIGURATION ---
-API_KEY   = os.environ["CRYPTOPANIC_API_KEY"]
 BOT_TOKEN = os.environ["TELEGRAM_TOKEN"]
 CHAT_ID   = os.environ["CHAT_ID"]
 
-URL = "https://cryptopanic.com/api/v1/posts/"
+FEED_URLS = [
+    "https://www.theblockcrypto.com/rss",
+    "https://decrypt.co/feed",
+    "https://cryptobriefing.com/feed/",
+]
 bot = Bot(token=BOT_TOKEN)
 
 def fetch_major_news():
-    params = {
-        "auth_token": API_KEY,
-        "public": "true",
-        "filter": "important",
-        "kind": "news"
-    }
-    r = requests.get(URL, params=params)
-    r.raise_for_status()
-    return r.json().get("results", [])
+    for url in FEED_URLS:
+        feed = feedparser.parse(url)
+        source = feed.feed.get("title", url)
+        for entry in feed.entries:
+            # try published_parsed then updated_parsed
+            t = entry.get("published_parsed") or entry.get("updated_parsed")
+            if not t:
+                continue
+            pub_date = datetime(*t[:6], tzinfo=timezone.utc)
+            yield {
+                "title": entry.get("title", ""),
+                "url": entry.get("link", ""),
+                "source": source,
+                "published_at": pub_date,
+            }
 
-def send_to_telegram(title, url, source, published_at):
+async def send_to_telegram(title, url, source, published_at):
+    safe_title = escape_markdown(title, version=2)
+    safe_source = escape_markdown(source, version=2)
     text = (
-        f"*{title}*\n"
-        f"Source : {source}\n"
+        f"*{safe_title}*\n"
+        f"Source : {safe_source}\n"
         f"Publiée à {published_at.strftime('%H:%M le %d/%m/%Y UTC')}\n"
         f"{url}"
     )
     # ton message de debug
     print("Posting:", title, published_at.isoformat(), url)
     # **bien indenté** dans la fonction
-    bot.send_message(chat_id=CHAT_ID, text=text, parse_mode="Markdown")
+    await bot.send_message(chat_id=CHAT_ID, text=text, parse_mode="MarkdownV2")
 
-def main():
+async def main():
     now = datetime.now(timezone.utc)
     window = now - timedelta(minutes=6)
     for post in fetch_major_news():
-        pub = datetime.fromisoformat(post["published_at"].replace("Z", "+00:00"))
+        pub = post["published_at"]
         if pub < window:
             continue
-        send_to_telegram(
+        await send_to_telegram(
             title=post["title"],
             url=post["url"],
-            source=post["source"]["title"],
-            published_at=pub
+            source=post["source"],
+            published_at=pub,
         )
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- switch script from CryptoPanic API to three public RSS feeds
- adjust parsing logic for feed entries
- update environment variable handling

## Testing
- `python -m py_compile script.py`
- `pip install feedparser python-telegram-bot`
- `CHAT_ID=1 TELEGRAM_TOKEN=bot_token python script.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68435b5f6e24832d9b9888857788bd13